### PR TITLE
Expose Slim::urlFor function to Twig templates

### DIFF
--- a/Views/TwigView.php
+++ b/Views/TwigView.php
@@ -84,6 +84,7 @@ class TwigView extends Slim_View {
                 $loader,
                 self::$twigOptions
             );
+			$this->twigEnvironment->addFunction('url', new Twig_Function_Function('Slim::urlFor'));
         }
         return $this->twigEnvironment;
     }


### PR DESCRIPTION
I find this pretty handy when building my templates.
