### PR TITLE
Fixed bug in CSRFGuard session checking code.

### DIFF
--- a/Middleware/CsrfGuard.php
+++ b/Middleware/CsrfGuard.php
@@ -54,7 +54,7 @@ class CsrfGuard extends Slim_Middleware {
      */
     public function check() {
         // Create token
-        if ( session_id() === "" ){
+        if ( session_id() !== "" ){
             if ( ! isset( $_SESSION[ $this->key ] ) ){
                 $_SESSION[ $this->key ] = sha1( serialize( $_SERVER ) . rand( 0, 0xffffffff ) );
             }


### PR DESCRIPTION
Previously an exception was thrown if sessions were enabled. An exception should only be thrown if sessions are disabled.
