### PR TITLE
Added file extension option to logger.

### DIFF
--- a/Log/DateTimeFileWriter.php
+++ b/Log/DateTimeFileWriter.php
@@ -68,6 +68,9 @@ class DateTimeFileWriter
      * name_format:
      * (string) The log file name format; parsed with `date()`.
      *
+     * extension:
+     * (string) The file extention to append to the filename`.     
+     *
      * message_format:
      * (string) The log message format; available tokens are...
      *     %label%      Replaced with the log message level (e.g. FATAL, ERROR, WARN).
@@ -83,6 +86,7 @@ class DateTimeFileWriter
         $this->settings = array_merge(array(
             'path' => './logs',
             'name_format' => 'Y-m-d',
+            'extension' => 'log',
             'message_format' => '%label% - %date% - %message%'
         ), $settings);
 
@@ -129,7 +133,12 @@ class DateTimeFileWriter
 
         //Open resource handle to log file
         if (!$this->resource) {
-            $this->resource = fopen($this->settings['path'] . DIRECTORY_SEPARATOR . date($this->settings['name_format']), 'a');
+            $filename = date($this->settings['name_format']);
+            if (! empty($this->settings['extension'])) {
+                $filename .= '.' . $this->settings['extension'];
+            }
+
+            $this->resource = fopen($this->settings['path'] . DIRECTORY_SEPARATOR . $filename, 'a');
         }
 
         //Output to resource


### PR DESCRIPTION
It would be nice if log files could have an extension so I added it as another constructor setting. I also set default file extension to `log` (E.g. `2012-01-01.log`) as I couldn't see any reason why they currently don't have one.
