### PR TITLE
Fixed incorrect Composer autoload path for Twig extension.

### DIFF
--- a/Middleware/CsrfGuard.php
+++ b/Middleware/CsrfGuard.php
@@ -10,28 +10,19 @@ class CsrfGuard extends \Slim\Middleware
 	 */
 	protected $key;
 
-    /**
-	 * CSRF graceful.
-	 *
-	 * @var string
-	 */
-	protected $graceful;	
-
 	/**
 	 * Constructor.
 	 *
-	 * @param boolean 	$graceful 	If true then destroy the session (graceful), otherwise halt the application (ungraceful).
 	 * @param string 	$key 		The CSRF token key name.
 	 * @return void
 	 */
-	public function __construct($graceful = false, $key = 'csrf_token')
+	public function __construct($key = 'csrf_token')
 	{
 		if (! is_string($key) || empty($key) || preg_match('/[^a-zA-Z0-9\-\_]/', $key)) {
 			throw new \OutOfBoundsException('Invalid CSRF token key "' . $key . '"');
 		}
 
 		$this->key = $key;
-		$this->graceful = (bool) $graceful;
 	}
 
 	/**
@@ -70,11 +61,7 @@ class CsrfGuard extends \Slim\Middleware
 		if (in_array($this->app->request()->getMethod(), array('POST', 'PUT', 'DELETE'))) {
             $userToken = $this->app->request()->post($this->key);
             if ($token !== $userToken) {
-            	if (! $this->graceful) {
-            		$this->app->halt(400, 'Invalid or missing CSRF token.');
-            	} else {
-            		session_destroy();	
-            	}
+            	$this->app->halt(400, 'Invalid or missing CSRF token.');
             }
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Twig_Extensions_": "Views/Extension/",
+            "Twig_Extensions_": "Slim/Extras/Views/Extension/",
             "Slim\\Extras": "."
         }
     },


### PR DESCRIPTION
The Twig extension isn't getting autoloaded because of an incorrect path in `composer.json`. If you look at the `autoload_namespaces.php` generated by Composer it currently looks like this:

```
<?php
$vendorDir = dirname(__DIR__);
$baseDir = dirname($vendorDir);

return array(
    'Twig_Extensions_' => $vendorDir . '/slim/extras/Views/Extension/',
);
```

When the Slim Extras repository is pulled down it ends up in `./vendor/slim/extras/Slim/Extras`. This means Composer is looking for the `Twig_Extensions_Slim` class in `./vendor/slim/extras/View/Extension`, which doesn't exist. I changed the autoload directory to `Slim/Extras/View/Extention` instead and the `autoload_namespaces.php` now looks in the correct directory:

```
<?php
$vendorDir = dirname(__DIR__);
$baseDir = dirname($vendorDir);

return array(
    'Twig_Extensions_' => $vendorDir . '/slim/extras/Slim/Extras/Views/Extension/',
);
```

I'm not sure if this is the best way to solve the problem, but it does appear to work. The only other option I can see is to use classmap autoloading instead.
