### PR TITLE
Fixed incorrect autoload directory for Twig Extensions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Twig_Extensions_": "Views/Extension/",
+            "Twig_Extensions_": "Slim/Extras/Views/Extension/",
             "Slim\\Extras": "."
         }
     },


### PR DESCRIPTION
The Twig extension isn't getting autoloaded because of an incorrect path in `composer.json`. If you look at the `autoload_namespaces.php` generated by Composer it currently looks like this:

```
<?php
$vendorDir = dirname(__DIR__);
$baseDir = dirname($vendorDir);

return array(
    'Twig_Extensions_' => $vendorDir . '/slim/extras/Views/Extension/',
);
```

When the Slim Extras repository is pulled down it ends up in `./vendor/slim/extras/Slim/Extras`. This means Composer is looking for the `Twig_Extensions_Slim` class in `./vendor/slim/extras/View/Extension`, which doesn't exist. I changed the autoload directory to `Slim/Extras/View/Extention` instead and the `autoload_namespaces.php` now looks in the correct directory:

```
<?php
$vendorDir = dirname(__DIR__);
$baseDir = dirname($vendorDir);

return array(
    'Twig_Extensions_' => $vendorDir . '/slim/extras/Slim/Extras/Views/Extension/',
);
```

Another option is to use classmap autoloading instead perhaps?
