### PR TITLE
Twig view tweaks

### DIFF
--- a/Views/README.markdown
+++ b/Views/README.markdown
@@ -17,8 +17,37 @@ library. You can use the Twig custom view in your Slim Framework application lik
 If you are not using Composer to autoload project dependencies, you must also set the Twig view's public static
 `$twigDirectory` property; this is the relative or absolute path to the directory that conatins the Twig library.
 
-You may also set the public static `$twigOptions` property; this is an array of settings that customize the Twig
-library behavior.
+### Twig configuration
+
+There are several public static properties you can use to customize the Twig library behavior.
+
+####$twigOptions
+
+An array of options to pass to the underlying Twig environment ([Twig docs](http://twig.sensiolabs.org/doc/api.html#environment-options)):
+
+	\Slim\Extras\Views\Twig::$twigOptions = array(
+		'debug' => true
+	);
+
+
+####$twigExtensions
+
+An array contianing Twig extensions to load ([Twig docs](http://twig.sensiolabs.org/doc/advanced.html)):
+
+	\Slim\Extras\Views\Twig::$twigExtensions = array(
+		new MyCustomExtension(),
+		new ThirdPartyExtension()
+	);
+
+
+####$twigTemplateDirs
+
+An array of paths to directories containing Twig templates ([Twig docs](http://twig.sensiolabs.org/doc/api.html#twig-loader-filesystem)):
+
+	\Slim\Extras\Views\Twig::$twigTemplateDirs = array(
+		realpath(PROJECT_DIR . '/templates'),
+		realpath(PROJECT_DIR . '/some/other/templates')
+	);
 
 ## Mustache
 

--- a/Views/Twig.php
+++ b/Views/Twig.php
@@ -47,6 +47,11 @@ class Twig extends \Slim\View
     public static $twigDirectory = null;
 
     /**
+     * @var array Paths to directories to attempt to load Twig template from
+     */
+    public static $twigTemplateDirs = array();
+
+    /**
      * @var array The options for the Twig environment, see
      * http://www.twig-project.org/book/03-Twig-for-Developers
      */
@@ -61,6 +66,22 @@ class Twig extends \Slim\View
      * @var TwigEnvironment The Twig environment for rendering templates.
      */
     private $twigEnvironment = null;
+
+    /**
+     * Get a list of template directories
+     *
+     * Returns an array of templates defined by self::$twigTemplateDirs, falls
+     * back to Slim\View's built-in getTemplatesDirectory method.
+     *
+     * @return array
+     **/
+    private function getTemplateDirs()
+    {
+        if (empty(self::$twigTemplateDirs)) {
+            return array($this->getTemplatesDirectory());
+        }
+        return self::$twigTemplateDirs;
+    }
 
     /**
      * Render Twig Template
@@ -92,7 +113,7 @@ class Twig extends \Slim\View
             }
 
             \Twig_Autoloader::register();
-            $loader = new \Twig_Loader_Filesystem($this->getTemplatesDirectory());
+            $loader = new \Twig_Loader_Filesystem($this->getTemplateDirs());
             $this->twigEnvironment = new \Twig_Environment(
                 $loader,
                 self::$twigOptions


### PR DESCRIPTION
While working on a project using Slim + Twig, I've run into a use case where I want to use Twig's ability to traverse multiple template directories to load and render a template.

This pull request adds a public static property called `$twigTemplateDirs` to the `\Slim\Extras\Views\Twig.php` file that allows a user to set an array of directories for Twig to use. If this array is empty, it falls back to the current behavior of using the parent class' `getTemplatesDirectory()` method.

I also added documentation for all the available public static properties on the Twig view class.

If there's a smarter way to do this in Slim or just an option/feature I'm missing in Slim itself let me know. Thanks!
