### PR TITLE
Update Mustache View implementation.

### DIFF
--- a/Views/Mustache.php
+++ b/Views/Mustache.php
@@ -63,9 +63,7 @@ class Mustache extends \Slim\View
      */
     public function render($template)
     {
-        $m = $this->getEngine();
-        $contents = file_get_contents($this->getTemplatesDirectory() . '/' . ltrim($template, '/'));
-        return $m->render($contents, $this->data);
+        return $this->getEngine()->render($template, $this->data);
     }
 
     /**
@@ -82,7 +80,10 @@ class Mustache extends \Slim\View
                 \Mustache_Autoloader::register(dirname(self::$mustacheDirectory));
             }
 
-            $this->engine = new \Mustache_Engine();
+            $this->engine = new \Mustache_Engine(array(
+                // Autoload templates (and partials) from the templates directory.
+                'loader' => new \Mustache_Loader_FilesystemLoader($this->getTemplatesDirectory()),
+            ));
         }
 
         return $this->engine;

--- a/Views/Mustache.php
+++ b/Views/Mustache.php
@@ -58,8 +58,12 @@ class Mustache extends \Slim\View
      */
     public function render($template)
     {
-        require_once self::$mustacheDirectory . '/Autoloader.php';
-        \Mustache_Autoloader::register(dirname(self::$mustacheDirectory));
+        // Check for Composer autoloading
+        if (!class_exists('\Mustache_Engine')) {
+            require_once self::$mustacheDirectory . '/Autoloader.php';
+            \Mustache_Autoloader::register(dirname(self::$mustacheDirectory));
+        }
+
         $m = new \Mustache_Engine();
         $contents = file_get_contents($this->getTemplatesDirectory() . '/' . ltrim($template, '/'));
         return $m->render($contents, $this->data);

--- a/Views/Mustache.php
+++ b/Views/Mustache.php
@@ -102,6 +102,11 @@ class Mustache extends \Slim\View
                 $options['loader'] = new \Mustache_Loader_FilesystemLoader($this->getTemplatesDirectory());
             }
 
+            // If a partials loader is not specified, fall back to the default template loader.
+            if (!isset($options['partials_loader']) && !isset($options['partials'])) {
+                $options['partials_loader'] = $options['loader'];
+            }
+
             $this->engine = new \Mustache_Engine($options);
         }
 

--- a/Views/Mustache.php
+++ b/Views/Mustache.php
@@ -50,6 +50,11 @@ class Mustache extends \Slim\View
     public static $mustacheDirectory = null;
 
     /**
+     * @var \Mustache_Engine A Mustache engine instance for this view
+     */
+    private $engine;
+
+    /**
      * Renders a template using Mustache.php.
      *
      * @see View::render()
@@ -58,14 +63,28 @@ class Mustache extends \Slim\View
      */
     public function render($template)
     {
-        // Check for Composer autoloading
-        if (!class_exists('\Mustache_Engine')) {
-            require_once self::$mustacheDirectory . '/Autoloader.php';
-            \Mustache_Autoloader::register(dirname(self::$mustacheDirectory));
-        }
-
-        $m = new \Mustache_Engine();
+        $m = $this->getEngine();
         $contents = file_get_contents($this->getTemplatesDirectory() . '/' . ltrim($template, '/'));
         return $m->render($contents, $this->data);
+    }
+
+    /**
+     * Get a \Mustache_Engine instance.
+     *
+     * @return \Mustache_Engine
+     */
+    private function getEngine()
+    {
+        if (!isset($this->engine)) {
+            // Check for Composer autoloading
+            if (!class_exists('\Mustache_Engine')) {
+                require_once self::$mustacheDirectory . '/Autoloader.php';
+                \Mustache_Autoloader::register(dirname(self::$mustacheDirectory));
+            }
+
+            $this->engine = new \Mustache_Engine();
+        }
+
+        return $this->engine;
     }
 }

--- a/Views/Mustache.php
+++ b/Views/Mustache.php
@@ -50,9 +50,24 @@ class Mustache extends \Slim\View
     public static $mustacheDirectory = null;
 
     /**
+     * @var array An array of \Mustache_Engine options
+     */
+    public static $mustacheOptions = array();
+
+    /**
      * @var \Mustache_Engine A Mustache engine instance for this view
      */
-    private $engine;
+    private $engine = null;
+
+    /**
+     * @param array $options \Mustache_Engine configuration options
+     */
+    public function __construct(array $options = null)
+    {
+        if ($options !== null) {
+            self::$mustacheOptions = $options;
+        }
+    }
 
     /**
      * Renders a template using Mustache.php.
@@ -80,10 +95,14 @@ class Mustache extends \Slim\View
                 \Mustache_Autoloader::register(dirname(self::$mustacheDirectory));
             }
 
-            $this->engine = new \Mustache_Engine(array(
-                // Autoload templates (and partials) from the templates directory.
-                'loader' => new \Mustache_Loader_FilesystemLoader($this->getTemplatesDirectory()),
-            ));
+            $options = self::$mustacheOptions;
+
+            // Autoload templates from the templates directory.
+            if (!isset($options['loader'])) {
+                $options['loader'] = new \Mustache_Loader_FilesystemLoader($this->getTemplatesDirectory());
+            }
+
+            $this->engine = new \Mustache_Engine($options);
         }
 
         return $this->engine;


### PR DESCRIPTION
- Only `require_once` and use the Mustache autoloader if Composer autoloading isn't already present.
- Instantiate a single Mustache engine instead of one per `render` call.
- Use a Mustache template loader rather than manually loading template contents.
- Use a Mustache template loader for partials, which makes them actually work :)
- Allow passing options to the Mustache engine. This is especially important for things like the `cache` option, which makes Mustache holy bacon faster than without it.
