### PR TITLE
fix Class 'Twig_Extensions_Slim' not found

### DIFF
--- a/Views/Twig.php
+++ b/Views/Twig.php
@@ -120,10 +120,10 @@ class Twig extends \Slim\View
             );
 
             // Check for Composer Package Autoloader class loading
-            if (!class_exists('\Twig_Extensions_Autoloader')) {
+//            if (!class_exists('\Twig_Extensions_Autoloader')) {
                 $extension_autoloader = dirname(__FILE__) . '/Extension/TwigAutoloader.php';
                 if (file_exists($extension_autoloader)) require_once $extension_autoloader;
-            }
+//            }
 
             if (class_exists('\Twig_Extensions_Autoloader')) {
                 \Twig_Extensions_Autoloader::register();


### PR DESCRIPTION
I'm keep getting

PHP Fatal error:  Class 'Twig_Extensions_Slim' not found in web/vendor/slim/extras/Slim/Extras/Views/Twig.php on line 133

which dues to

```
        // Check for Composer Package Autoloader class loading
        if (!class_exists('\Twig_Extensions_Autoloader')) {
            $extension_autoloader = dirname(__FILE__) . '/Extension/TwigAutoloader.php';
            if (file_exists($extension_autoloader)) require_once $extension_autoloader;
        }
```

already loaded vendor/twig/extensions/lib/Twig/Extensions/Autoloader.php
so the vendor/slim/extras/Slim/Extras/Views/Extension/TwigAutoloader.php is not loaded at all.

the fixes force to load vendor/slim/extras/Slim/Extras/Views/Extension/TwigAutoloader.php always (do not check class_exists).

newbie to php and hope it's fine.

Thanks
