### PR TITLE
Allow passing format string for log date format.

### DIFF
--- a/Log/DateTimeFileWriter.php
+++ b/Log/DateTimeFileWriter.php
@@ -86,6 +86,7 @@ class DateTimeFileWriter
         $this->settings = array_merge(array(
             'path' => './logs',
             'name_format' => 'Y-m-d',
+            'date_format' => 'c',
             'extension' => 'log',
             'message_format' => '%label% - %date% - %message%'
         ), $settings);
@@ -127,7 +128,7 @@ class DateTimeFileWriter
             '%message%'
         ), array(
             $label,
-            date('c'),
+            date($this->settings['date_format']),
             (string)$object
         ), $this->settings['message_format']);
 


### PR DESCRIPTION
Sometimes you want something else than ISO 8601 date. This patch allows you to pass date format string when you initialize logger. For example something like:

$app = new \Slim\Slim(array(
    "log.writer" => new \Slim\Extras\Log\DateTimeFileWriter(array(
        "path" => "./logs",
        "name_format" => "Y-m-d",
        "date_format" => "Y-m-d H:i:s",
        "message_format" => "%label% [%date%] %message%"
    ))
));
