### PR TITLE
A small patch to allow the Twig view to work with Slim 2.3's view API

### DIFF
--- a/Views/Twig.php
+++ b/Views/Twig.php
@@ -96,7 +96,7 @@ class Twig extends \Slim\View
         $env = $this->getEnvironment();
         $template = $env->loadTemplate($template);
 
-        return $template->render($this->data);
+        return $template->render($this->all());
     }
 
     /**


### PR DESCRIPTION
I think there is in an incompatibility between Slim 2.3's view API, and the current version of the Twig View shipped in Slim Extras.

I believe that the incompatibility was introduced when Slim started to use Slim sets (rather than PHP arrays) as the type of View#data: https://github.com/codeguy/Slim/commit/5ec3f4b169876c2a6807f8a88172e463cf56a35d

In brief, the render method of a Twig template expects an array, but a Slim set is now passed. I've fixed this by having the Twig view call the new all() method, rather than referring to $this->data directly.
