### PR TITLE
Updated \Slim\View\Mustache::render() function to work with Slim 2.3.1

### DIFF
--- a/Views/Mustache.php
+++ b/Views/Mustache.php
@@ -62,6 +62,6 @@ class Mustache extends \Slim\View
         \Mustache_Autoloader::register(dirname(self::$mustacheDirectory));
         $m = new \Mustache_Engine();
         $contents = file_get_contents($this->getTemplatesDirectory() . '/' . ltrim($template, '/'));
-        return $m->render($contents, $this->data);
+        return $m->render($contents, $this->data->all());
     }
 }


### PR DESCRIPTION
Mustache requires an array()
