### PR TITLE
Allow basic auth with empty username

### DIFF
--- a/Middleware/HttpBasicAuth.php
+++ b/Middleware/HttpBasicAuth.php
@@ -81,7 +81,8 @@ class HttpBasicAuth extends \Slim\Middleware
         $res = $this->app->response();
         $authUser = $req->headers('PHP_AUTH_USER');
         $authPass = $req->headers('PHP_AUTH_PW');
-        if ($authUser && $authPass && $authUser === $this->username && $authPass === $this->password) {
+        if (is_string($authUser) && is_string($authPass)
+				&& $authUser === $this->username && $authPass === $this->password) {
             $this->next->call();
         } else {
             $res->status(401);


### PR DESCRIPTION
I am developing a service right now that is explicitly required to use basic auth while only checking the password, not the username. So I tried setting the username to `""`, but that does not work with the current implementation of HttpBasicAuth. This patch enables it.
