### PR TITLE
More secure token generate

### DIFF
--- a/Middleware/CsrfGuard.php
+++ b/Middleware/CsrfGuard.php
@@ -64,7 +64,11 @@ class CsrfGuard extends \Slim\Middleware
         }
 
         if (! isset($_SESSION[$this->key])) {
-            $_SESSION[$this->key] = sha1(serialize($_SERVER) . rand(0, 0xffffffff));
+            if(function_exists('openssl_random_pseudo_bytes')){
+                $_SESSION[$this->key] = bin2hex(openssl_random_pseudo_bytes(20));
+            }else{
+                $_SESSION[$this->key] = sha1(serialize($_SERVER) . rand(0, 0xffffffff));
+            }
         }
 
         $token = $_SESSION[$this->key];


### PR DESCRIPTION
Use openssl_random_pseudo_bytes().

New token length is 40, used char is [a-f0-9](hex string), it same as previous.
If openssl_random_pseudo_bytes couldn't use, It will fallback to previous logic.
