### PR TITLE
Use mustache to the fullest abilities

### DIFF
--- a/Views/Mustache.php
+++ b/Views/Mustache.php
@@ -58,10 +58,13 @@ class Mustache extends \Slim\View
      */
     public function render($template)
     {
+        $tempDir = $this->getTemplatesDirectory();
         require_once self::$mustacheDirectory . '/Autoloader.php';
         \Mustache_Autoloader::register(dirname(self::$mustacheDirectory));
-        $m = new \Mustache_Engine();
-        $contents = file_get_contents($this->getTemplatesDirectory() . '/' . ltrim($template, '/'));
-        return $m->render($contents, $this->data);
+        $m = new \Mustache_Engine(array(
+            'loader' => new \Mustache_Loader_FilesystemLoader($tempDir),
+            'partials_loader' => new \Mustache_Loader_FilesystemLoader($tempDir.'/partials')
+        ));
+        return $m->render($template, $this->data);
     }
 }


### PR DESCRIPTION
Having used mustache for 95% of my projects, this is my standard setup (with or without Slim)

This allows you to pass the template name (index vs index.mustache) and allow you to still use partials (a very powerful feature of Mustache)

This does require that you have the template directory defined, and a directory called 'partials' inside the templates directory but if you use Mustache a lot, this is probably a very common setup for you.
