### PR TITLE
Twig_Template does not accept an object for render method

### DIFF
--- a/Views/Twig.php
+++ b/Views/Twig.php
@@ -96,7 +96,7 @@ class Twig extends \Slim\View
         $env = $this->getEnvironment();
         $template = $env->loadTemplate($template);
 
-        return $template->render($this->data);
+        return $template->render($this->data->all());
     }
 
     /**


### PR DESCRIPTION
Twig_Template render method accepts arrays not objects, the all() method of Slim\Helper\Set seems to work for this issue.
